### PR TITLE
"OpenBSD on the Desktop" updated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ A curated list of awesome applications, software, tools, and resources for using
 
 ## Desktop setup guides
 
-- [OpenBSD on the Desktop (Part I) by Patrick Bucher](https://paedubucher.ch/articles/2020-09-05-openbsd-on-the-desktop-part-i.html)
-- [OpenBSD on the Desktop (Part II) by Patrick Bucher](https://paedubucher.ch/articles/2020-09-12-openbsd-on-the-desktop-part-ii.html)
+- [OpenBSD on the Desktop (Part I) by Patrick Bucher](https://www.paedubucher.ch/articles/open-bsd-on-the-desktop-part-1/)
+- [OpenBSD on the Desktop (Part II) by Patrick Bucher](https://www.paedubucher.ch/articles/open-bsd-on-the-desktop-part-2/)
 - [OpenBSD desktop first steps by Sándor Czettner](https://www.czettner.com/2022/05/15/openbsd-desktop-first-steps.html)
 - [OpenBSD on a Laptop by c0ffee.net](https://www.c0ffee.net/blog/openbsd-on-a-laptop)
 - [OpenBSD Minimalist Desktop by Daniel Nechtan](https://www.nechtan.io/articles/openbsd_minimalist_desktop.html)


### PR DESCRIPTION
Hello, I just noticed that the two urls were going 404 and got the new ones from the [same website](https://paedubucher.ch/tags/openbsd/). I think the CMS on the website was updated.